### PR TITLE
Move deploy webhooks to vault and allow different webhooks per site

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,17 @@ deploy_after:
   - "{{ playbook_dir }}/vendor/roles/slack-notify/tasks/deploy_success.yml"
 ```
 
-Add your Slack webhook token (end of the webhook URL) and channel into `group_vars/all/main.yml`
+Add your Slack webhook token(s) (end of the webhook URL) and channel into `group_vars/{environment}/vault.yml`
 
 ```yaml
-# group_vars/all/main.yml
-slack_notifications:
-  - name: Organisation1
-    token: XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXX
-    channel: "#site-status"
-  - name: Organisation2
-    token: XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXX
-    channel: "#deployments"
+# group_vars/{environment}/vault.yml
+vault_wordpress_sites:
+  example.com.au:
+    slack_deploy_token:
+      - XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXX
+      - XXXXXXXXX/XXXXXXXXX/XXXXXXXXXXXXXXXXXXXXXXX
+    env:
+      ...
 ```
 
 ## Usage
@@ -98,6 +98,8 @@ slack_notifications:
 2. Create an App (e.g. "Deployment alerts") and enable "Incoming Webhooks"
 3. Setup a Webhook for your desired Workspace
 4. Copy the Webhook URL for use in [Installation](#installation)
+
+Note: Each Webhook can only post to one channel since Slack changed their API. You will need to set up a webhook per channel you wish to notify.
 
 ## See Also
 

--- a/tasks/deploy_start.yml
+++ b/tasks/deploy_start.yml
@@ -1,14 +1,15 @@
 ---
 - name: Send initial deployment notification to Slack
   slack:
-    token: "{{ item.token }}"
-    channel: "{{ item.channel }}"
+    token: "{{ slack_deploy_token }}"
     attachments:
       - text: "*{{ lookup('pipe', 'git config user.name') }}* has started deploying {{ site }} to *<https://{{ project.site_hosts | map(attribute='canonical') | first }}|{{ env }}>*"
         color: warning
-  loop: "{{ slack_notifications }}"
+  with_items: "{{ vault_wordpress_sites[site].slack_deploy_token }}"
+  loop_control:
+    loop_var: slack_deploy_token
   when:
-    - slack_notifications is defined
-    - slack_notifications | length > 0
+    - vault_wordpress_sites[site].slack_deploy_token is defined
+    - vault_wordpress_sites[site].slack_deploy_token | length > 0
   delegate_to: localhost
   ignore_errors: yes

--- a/tasks/deploy_success.yml
+++ b/tasks/deploy_success.yml
@@ -15,14 +15,15 @@
 
 - name: Send successful deployment notification to Slack
   slack:
-    token: "{{ item.token }}"
-    channel: "{{ item.channel }}"
+    token: "{{ slack_deploy_token }}"
     attachments:
       - text: "*{{ git_username }}* successfully deployed {{ site }} to *<{{ target_env_url }}>* {% if using_github %} [<{{ github_commit_url }}|deployed commit>] {% else %} [{{ git_clone.after }}] {% endif %}"
         color: good
-  loop: "{{ slack_notifications }}"
+  with_items: "{{ vault_wordpress_sites[site].slack_deploy_token }}"
+  loop_control:
+    loop_var: slack_deploy_token
   when:
-    - slack_notifications is defined
-    - slack_notifications | length > 0
+    - vault_wordpress_sites[site].slack_deploy_token is defined
+    - vault_wordpress_sites[site].slack_deploy_token | length > 0
   delegate_to: localhost
   ignore_errors: yes


### PR DESCRIPTION
@mike-sheppard building on what you'd done previously, this PR moves webhook tokens to an environment's `vault.yml` and allows you to notify multiple channels per site, per environment.

Looks like since you submitted your PR the Slack API has changed (unless I'm missing something?) so that a webhook can only notify one channel, so I've removed the ability to specify a channel. Each channel you wish to notify must have it's own webhook set up: in our use case this is perfect as we have a Slack channel per client, and an `engineering` channel that we can post staging deploys to. Have tested this and it also works with channels shared with other teams. 

I'll submit this to Itineris, but figured as it's based on your work, I'd PR with your repo too.